### PR TITLE
Fix base path for less compiler

### DIFF
--- a/src/app/builder.service.ts
+++ b/src/app/builder.service.ts
@@ -23,7 +23,7 @@ export class BuilderService {
         const compilerOptions = { math: 'always', useFileCache: true };
 
         if(semver.gte(version, '19.2.0-dev')) {
-            compilerOptions['filename'] = '/devextreme-themebuilder/data/less/bundles/bundle.less'; // fake path to the bundle
+            compilerOptions['filename'] = document.baseURI + 'devextreme-themebuilder/data/less/bundles/bundle.less'; // fake path to the bundle
         }
 
         this.lessCompiler = lessCompiler(window, compilerOptions);


### PR DESCRIPTION
Less compiler has its own url handler that does not watch on the base tag